### PR TITLE
Added support for individual rounded corners in the experimental backend

### DIFF
--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -189,7 +189,13 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 
 		// Store the window background for rounded corners
 		// If rounded corners backup the region first
-		if (w->corner_radius > 0) {
+
+		bool has_corner_radius = w->corner_radius > 0.0 ||
+					 w->corner_radius_top_left > 0.0 ||
+					 w->corner_radius_top_right > 0.0 ||
+					 w->corner_radius_bottom_left > 0.0 ||
+					 w->corner_radius_bottom_left > 0.0;
+		if (has_corner_radius) {
 			const int16_t x = w->g.x;
 			const int16_t y = w->g.y;
 			const auto wid = to_u16_checked(w->widthb);
@@ -391,7 +397,7 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 		}
 
 		// Round the corners as last step after blur/shadow/dim/etc
-		if (w->corner_radius > 0.0) {
+		if (has_corner_radius) {
 			ps->backend_data->ops->round(ps->backend_data, w,
 						ps->backend_round_context, w->win_image,
 						&reg_bound, &reg_visible);

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -75,6 +75,10 @@ struct kernel_blur_args {
 
 struct round_corners_args {
 	int corner_radius;
+	int corner_radius_top_left;
+	int corner_radius_top_right;
+	int corner_radius_bottom_right;
+	int corner_radius_bottom_left;
 	bool round_borders;
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -526,6 +526,10 @@ void set_default_winopts(options_t *opt, win_option_mask_t *mask, bool shadow_en
 		}
         if (!mask[i].corner_radius) {
             opt->wintype_option[i].corner_radius = -1;
+            opt->wintype_option[i].corner_radius_top_left = -1;
+            opt->wintype_option[i].corner_radius_top_right = -1;
+            opt->wintype_option[i].corner_radius_bottom_right = -1;
+            opt->wintype_option[i].corner_radius_bottom_left = -1;
         }
         if (!mask[i].round_borders) {
             opt->wintype_option[i].round_borders = -1;
@@ -603,6 +607,11 @@ char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
 
 	    .track_leader = false,
 
+		.corner_radius = 0,
+		.corner_radius_top_left = -1,
+		.corner_radius_top_right = -1,
+		.corner_radius_bottom_right = -1,
+		.corner_radius_bottom_left = -1,
 		.rounded_corners_blacklist = NULL,
 		.round_borders_blacklist = NULL,
 		.round_borders_rules = NULL

--- a/src/config.h
+++ b/src/config.h
@@ -56,6 +56,10 @@ typedef struct win_option {
 	bool redir_ignore;
 	double opacity;
     int corner_radius;
+    int corner_radius_top_left;
+    int corner_radius_top_right;
+    int corner_radius_bottom_right;
+    int corner_radius_bottom_left;
     int round_borders;
 } win_option_t;
 
@@ -255,6 +259,10 @@ typedef struct options {
 
 	// === Rounded corners related ===
 	int corner_radius;
+	int corner_radius_top_left;
+	int corner_radius_top_right;
+	int corner_radius_bottom_right;
+	int corner_radius_bottom_left;
 	/// Rounded corners blacklist. A linked list of conditions.
 	c2_lptr_t *rounded_corners_blacklist;
     /// Do we round the borders of rounded windows?

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -315,6 +315,26 @@ static inline void parse_wintype_config(const config_t *cfg, const char *member_
 			mask->corner_radius = true;
             //log_warn("%s: corner-radius: %d", member_name, ival);
 		}
+		if (config_setting_lookup_int(setting, "corner-radius-top-left", &ival)) {
+			o->corner_radius_top_left = ival;
+			mask->corner_radius = true;
+            //log_warn("%s: corner-radius: %d", member_name, ival);
+		}
+		if (config_setting_lookup_int(setting, "corner-radius-top-right", &ival)) {
+			o->corner_radius_top_right = ival;
+			mask->corner_radius = true;
+            //log_warn("%s: corner-radius: %d", member_name, ival);
+		}
+		if (config_setting_lookup_int(setting, "corner-radius-bottom-right", &ival)) {
+			o->corner_radius_bottom_right = ival;
+			mask->corner_radius = true;
+            //log_warn("%s: corner-radius: %d", member_name, ival);
+		}
+		if (config_setting_lookup_int(setting, "corner-radius-bottom-left", &ival)) {
+			o->corner_radius_bottom_left = ival;
+			mask->corner_radius = true;
+            //log_warn("%s: corner-radius: %d", member_name, ival);
+		}
         if (config_setting_lookup_int(setting, "round-borders", &ival)) {
 			o->round_borders = ival;
 			mask->round_borders = true;
@@ -406,6 +426,14 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 		opt->active_opacity = normalize_d(dval);
 	// --corner-radius
 	config_lookup_int(&cfg, "corner-radius", &opt->corner_radius);
+	// --corner-radius-top-left
+	config_lookup_int(&cfg, "corner-radius-top-left", &opt->corner_radius_top_left);
+	// --corner-radius-top-right
+	config_lookup_int(&cfg, "corner-radius-top-right", &opt->corner_radius_top_right);
+	// --corner-radius-bottom-right
+	config_lookup_int(&cfg, "corner-radius-bottom-right", &opt->corner_radius_bottom_right);
+	// --corner-radius-bottom-left
+	config_lookup_int(&cfg, "corner-radius-bottom-left", &opt->corner_radius_bottom_left);
 	// --rounded-corners-exclude
 	parse_cfg_condlst(&cfg, &opt->rounded_corners_blacklist, "rounded-corners-exclude");
 	// --round-borders

--- a/src/options.c
+++ b/src/options.c
@@ -115,7 +115,12 @@ static void usage(const char *argv0, int ret) {
 	    "  Default opacity for active windows. (0.0 - 1.0)\n"
 	    "\n"
             "--corner-radius value\n"
+            "--corner-radius-top-left value\n"
+            "--corner-radius-top-right value\n"
+            "--corner-radius-bottom-right value\n"
+            "--corner-radius-bottom-left value\n"
             "  Round the corners of windows. (defaults to 0)\n"
+            "  Individual rounded corners (e.g. top-left) have higher precedence than --corner-radius\n"
             "\n"
             "--rounded-corners-exclude condition\n"
             "  Exclude conditions for rounded corners.\n"
@@ -456,10 +461,14 @@ static const struct option longopts[] = {
     {"blur-deviation", required_argument, NULL, 330},
     {"blur-strength", required_argument, NULL, 331},
     {"corner-radius", required_argument, NULL, 332},
-    {"rounded-corners-exclude", required_argument, NULL, 333},
-    {"round-borders", required_argument, NULL, 334},
-    {"round-borders-exclude", required_argument, NULL, 335},
-    {"round-borders-rule", required_argument, NULL, 336},
+    {"corner-radius-top-left", required_argument, NULL, 333},
+    {"corner-radius-top-right", required_argument, NULL, 334},
+    {"corner-radius-bottom-right", required_argument, NULL, 335},
+    {"corner-radius-bottom-left", required_argument, NULL, 336},
+    {"rounded-corners-exclude", required_argument, NULL, 337},
+    {"round-borders", required_argument, NULL, 338},
+    {"round-borders-exclude", required_argument, NULL, 339},
+    {"round-borders-rule", required_argument, NULL, 340},
     {"experimental-backends", no_argument, NULL, 733},
     {"monitor-repaint", no_argument, NULL, 800},
     {"diagnostics", no_argument, NULL, 801},
@@ -869,10 +878,14 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 			opt->blur_strength = parse_kawase_blur_strength(atoi(optarg));
 			break;
 		case 332: opt->corner_radius = atoi(optarg); break;
-		case 333: condlst_add(&opt->rounded_corners_blacklist, optarg); break;
-		case 334: opt->round_borders = atoi(optarg); break;
-		case 335: condlst_add(&opt->round_borders_blacklist, optarg); break;
-		case 336:
+		case 333: opt->corner_radius_top_left = atoi(optarg); break;
+		case 334: opt->corner_radius_top_right = atoi(optarg); break;
+		case 335: opt->corner_radius_bottom_right = atoi(optarg); break;
+		case 336: opt->corner_radius_bottom_left = atoi(optarg); break;
+		case 337: condlst_add(&opt->rounded_corners_blacklist, optarg); break;
+		case 338: opt->round_borders = atoi(optarg); break;
+		case 339: condlst_add(&opt->round_borders_blacklist, optarg); break;
+		case 340:
 			// --round_borders_rule
 			if (!parse_rule_border(&opt->round_borders_rules, optarg))
 				exit(1);

--- a/src/picom.c
+++ b/src/picom.c
@@ -759,6 +759,10 @@ static bool initialize_blur(session_t *ps) {
 static bool initialize_round_corners(session_t *ps) {
 	struct round_corners_args cargs;
 	cargs.corner_radius = ps->o.corner_radius;
+	cargs.corner_radius_top_left = ps->o.corner_radius_top_left;
+	cargs.corner_radius_top_right = ps->o.corner_radius_top_right;
+	cargs.corner_radius_bottom_right = ps->o.corner_radius_bottom_right;
+	cargs.corner_radius_bottom_left = ps->o.corner_radius_bottom_left;
 	cargs.round_borders = ps->o.round_borders;
 	ps->backend_round_context = ps->backend_data->ops->create_round_context(
 	    ps->backend_data, &cargs);
@@ -790,6 +794,7 @@ static bool initialize_backend(session_t *ps) {
 		if (!initialize_round_corners(ps)) {
 			log_fatal("Failed to prepare for rounded corners, will ignore...");
 			ps->o.corner_radius = 0;
+			ps->o.corner_radius_top_left = ps->o.corner_radius_top_right = ps->o.corner_radius_bottom_right = ps->o.corner_radius_bottom_left = -1;
 		}
 
 		// window_stack shouldn't include window that's

--- a/src/win.c
+++ b/src/win.c
@@ -921,6 +921,10 @@ static void win_determine_rounded_corners(session_t *ps, struct managed_win *w) 
 		//log_warn("xy(%d %d) wh(%d %d) will NOT round corners", w->g.x, w->g.y, w->widthb, w->heightb);
 	} else {
 		w->corner_radius = ps->o.corner_radius;
+		w->corner_radius_top_left = ps->o.corner_radius_top_left;
+		w->corner_radius_top_right = ps->o.corner_radius_top_right;
+		w->corner_radius_bottom_right = ps->o.corner_radius_bottom_right;
+		w->corner_radius_bottom_left = ps->o.corner_radius_bottom_left;
 		//log_warn("xy(%d %d) wh(%d %d) will round corners", w->g.x, w->g.y, w->widthb, w->heightb);
 
 		// HACK: we reset this so we can query the color once
@@ -933,6 +937,26 @@ static void win_determine_rounded_corners(session_t *ps, struct managed_win *w) 
             ps->o.wintype_option[w->window_type].corner_radius >= 0) {
 		    w->corner_radius = ps->o.wintype_option[w->window_type].corner_radius;
             //log_warn("xy(%d %d) wh(%d %d) wintypes:corner_radius: %d", w->g.x, w->g.y, w->widthb, w->heightb, w->corner_radius);
+        }
+	    if (!safe_isnan(ps->o.wintype_option[w->window_type].corner_radius_top_left) &&
+            ps->o.wintype_option[w->window_type].corner_radius_top_left >= 0) {
+		    w->corner_radius_top_left = ps->o.wintype_option[w->window_type].corner_radius_top_left;
+            //log_warn("xy(%d %d) wh(%d %d) wintypes:corner_radius_top_left: %d", w->g.x, w->g.y, w->widthb, w->heightb, w->corner_radius_top_left);
+        }
+	    if (!safe_isnan(ps->o.wintype_option[w->window_type].corner_radius_top_right) &&
+            ps->o.wintype_option[w->window_type].corner_radius_top_right >= 0) {
+		    w->corner_radius_top_right = ps->o.wintype_option[w->window_type].corner_radius_top_right;
+            //log_warn("xy(%d %d) wh(%d %d) wintypes:corner_radius_top_right: %d", w->g.x, w->g.y, w->widthb, w->heightb, w->corner_radius_top_right);
+        }
+	    if (!safe_isnan(ps->o.wintype_option[w->window_type].corner_radius_bottom_right) &&
+            ps->o.wintype_option[w->window_type].corner_radius_bottom_right >= 0) {
+		    w->corner_radius_bottom_right = ps->o.wintype_option[w->window_type].corner_radius_bottom_right;
+            //log_warn("xy(%d %d) wh(%d %d) wintypes:corner_radius_bottom_right: %d", w->g.x, w->g.y, w->widthb, w->heightb, w->corner_radius_bottom_right);
+        }
+	    if (!safe_isnan(ps->o.wintype_option[w->window_type].corner_radius_bottom_left) &&
+            ps->o.wintype_option[w->window_type].corner_radius_bottom_left >= 0) {
+		    w->corner_radius_bottom_left = ps->o.wintype_option[w->window_type].corner_radius_bottom_left;
+            //log_warn("xy(%d %d) wh(%d %d) wintypes:corner_radius_bottom_left: %d", w->g.x, w->g.y, w->widthb, w->heightb, w->corner_radius_bottom_left);
         }
 
 	    void *val = NULL;
@@ -1312,6 +1336,10 @@ struct win *fill_win(session_t *ps, struct win *w) {
 	    .shadow_paint = PAINT_INIT,
 
 		.corner_radius = 0,
+		.corner_radius_top_left = -1,
+		.corner_radius_top_right = -1,
+		.corner_radius_bottom_right = -1,
+		.corner_radius_bottom_left = -1,
 	};
 
 	assert(!w->destroyed);

--- a/src/win.h
+++ b/src/win.h
@@ -204,6 +204,10 @@ struct managed_win {
 
 	/// Corner radius
 	int corner_radius;
+	int corner_radius_top_left;
+	int corner_radius_top_right;
+	int corner_radius_bottom_right;
+	int corner_radius_bottom_left;
 	bool round_borders;
 	float border_col[4];
     uint16_t border_width;
@@ -448,14 +452,19 @@ struct managed_win *attr_pure win_stack_find_next_managed(const session_t *ps,
 void free_win_res(session_t *ps, struct managed_win *w);
 
 static inline void win_region_remove_corners(const struct managed_win *w, region_t *res) {
+	int top_left_radius = w->corner_radius_top_left >= 0 ? w->corner_radius_top_left : w->corner_radius;
+	int top_right_radius = w->corner_radius_top_right >= 0 ? w->corner_radius_top_right : w->corner_radius;
+	int bottom_left_radius = w->corner_radius_bottom_left >= 0 ? w->corner_radius_bottom_left : w->corner_radius;
+	int bottom_right_radius = w->corner_radius_bottom_right >= 0 ? w->corner_radius_bottom_right : w->corner_radius;
+
 	region_t corners;
 	pixman_region32_init_rects(
 		&corners,
 		(rect_t[]){
-			{.x1 = 0, .y1 = 0, .x2 = w->corner_radius, .y2 = w->corner_radius},
-			{.x1 = 0, .y1 = w->heightb-w->corner_radius, .x2 = w->corner_radius, .y2 = w->heightb},
-			{.x1 = w->widthb-w->corner_radius, .y1 = 0, .x2 = w->widthb, .y2 = w->corner_radius},
-			{.x1 = w->widthb-w->corner_radius, .y1 = w->heightb-w->corner_radius, .x2 = w->widthb, .y2 = w->heightb},
+			{.x1 = 0, .y1 = 0, .x2 = top_left_radius, .y2 = top_left_radius},
+			{.x1 = 0, .y1 = w->heightb-bottom_left_radius, .x2 = bottom_left_radius, .y2 = w->heightb},
+			{.x1 = w->widthb-top_right_radius, .y1 = 0, .x2 = w->widthb, .y2 = top_right_radius},
+			{.x1 = w->widthb-bottom_right_radius, .y1 = w->heightb-bottom_right_radius, .x2 = w->widthb, .y2 = w->heightb},
 		},
 		4);
 	pixman_region32_subtract(res, res, &corners);


### PR DESCRIPTION
This PR adds support for individual rounded corners, to be able to achieve the effect as discussed in my previous comment: https://github.com/yshui/picom/pull/361#issuecomment-646810128

Each rounded corner can be configured per window like `corner-radius` using the new config options `corner-radius-top-left`, `corner-radius-top-right`, `corner-radius-bottom-right` and `corner-radius-bottom-left`.

Though because the old backends are deprecated someday in the future I haven't added support for them.