### PR TITLE
Fixed condition tree joining

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,6 +39,7 @@ Richard Grenville <pyxlcy@gmail.com>
 Scott Leggett <scott@sl.id.au>
 Tasos Sahanidis <tasos@tasossah.com>
 The Gitter Badger <badger@gitter.im>
+Tiago Teles <git@tteles.dev>
 Tilman Sauerbeck <tilman@code-monkey.de>
 Tim van Dalen <Tim@timvdalen.nl>
 Uli Schlachter <psychon@znc.in>

--- a/src/c2.c
+++ b/src/c2.c
@@ -267,9 +267,10 @@ static inline void c2_ptr_reset(c2_ptr_t *pp) {
 static inline c2_ptr_t c2h_comb_tree(c2_b_op_t op, c2_ptr_t p1, c2_ptr_t p2) {
 	c2_ptr_t p = {.isbranch = true, .b = cmalloc(c2_b_t)};
 
+	p.b->neg = false;
+	p.b->op = op;
 	p.b->opr1 = p1;
 	p.b->opr2 = p2;
-	p.b->op = op;
 
 	return p;
 }
@@ -369,6 +370,7 @@ c2_lptr_t *c2_parse(c2_lptr_t **pcondlst, const char *pattern, void *data) {
 #ifdef DEBUG_C2
 		log_trace("(\"%s\"): ", pattern);
 		c2_dump(plptr->ptr);
+		putchar('\n');
 #endif
 
 		return plptr;
@@ -1507,8 +1509,11 @@ static bool c2_match_once(session_t *ps, const struct managed_win *w, const c2_p
 		}
 
 #ifdef DEBUG_WINMATCH
-		log_trace("(%#010lx): branch: result = %d, pattern = ", w->id, result);
+		log_trace("(%#010x): leaf: result = %d, error = %d, "
+		          "client = %#010x,  pattern = ",
+		          w->base.id, result, error, w->client_win);
 		c2_dump(cond);
+		putchar('\n');
 #endif
 	}
 	// Handle a leaf


### PR DESCRIPTION
Added mainline fixes by initializing c2_ptr_t correctly

This fixes an UB issue with settings containing branching, such as mine.
Example:
```
rounded-corners-exclude = [
	"!class_g = 'Spotify' && !class_g = 'discord'"
]
```
The intended result is to have rounded corners in only spotify and discord, but this only happens 50% of the time, the other 50% the opposite happens, only spotify and discord have rectangular corners.

This pull request fixes that by using [this patch](https://github.com/yshui/picom/commit/7077609c017148f6cab779eb8ed2964c247cabaa) from mainline picom.

Thank you!
